### PR TITLE
Logging proposal 

### DIFF
--- a/Kumo.podspec
+++ b/Kumo.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name            = 'Kumo'
-  s.version         = '2.0.0'
+  s.version         = '2.1.0'
   s.summary         = 'Simple networking with little boilerplate built with reactive programming.'
   s.homepage        = 'https://gitlab.duethealth.com/ios-projects/Dependencies/Kumo'
   s.license         = 'MIT'

--- a/Kumo.xcodeproj/project.pbxproj
+++ b/Kumo.xcodeproj/project.pbxproj
@@ -7,6 +7,8 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		2CC938642702916A00465C19 /* TestLogger.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2CC938632702916A00465C19 /* TestLogger.swift */; };
+		2CC938672702930800465C19 /* KumoLogger.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2CC938662702930800465C19 /* KumoLogger.swift */; };
 		9422A34F222B2CA40038E451 /* MockResponse.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9422A34E222B2CA40038E451 /* MockResponse.swift */; };
 		9422A352222B2F7A0038E451 /* NetworkTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9422A351222B2F7A0038E451 /* NetworkTest.swift */; };
 		9422A354222C267A0038E451 /* TestStructure.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9422A353222C267A0038E451 /* TestStructure.swift */; };
@@ -132,6 +134,8 @@
 /* End PBXCopyFilesBuildPhase section */
 
 /* Begin PBXFileReference section */
+		2CC938632702916A00465C19 /* TestLogger.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TestLogger.swift; sourceTree = "<group>"; };
+		2CC938662702930800465C19 /* KumoLogger.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = KumoLogger.swift; sourceTree = "<group>"; };
 		9422A34E222B2CA40038E451 /* MockResponse.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockResponse.swift; sourceTree = "<group>"; };
 		9422A351222B2F7A0038E451 /* NetworkTest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NetworkTest.swift; sourceTree = "<group>"; };
 		9422A353222C267A0038E451 /* TestStructure.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TestStructure.swift; sourceTree = "<group>"; };
@@ -255,6 +259,14 @@
 /* End PBXFrameworksBuildPhase section */
 
 /* Begin PBXGroup section */
+		2CC93865270292D000465C19 /* Logger */ = {
+			isa = PBXGroup;
+			children = (
+				2CC938662702930800465C19 /* KumoLogger.swift */,
+			);
+			path = Logger;
+			sourceTree = "<group>";
+		};
 		9422A344222B034B0038E451 /* Mocks */ = {
 			isa = PBXGroup;
 			children = (
@@ -269,6 +281,7 @@
 			children = (
 				9422A351222B2F7A0038E451 /* NetworkTest.swift */,
 				9422A353222C267A0038E451 /* TestStructure.swift */,
+				2CC938632702916A00465C19 /* TestLogger.swift */,
 			);
 			path = Common;
 			sourceTree = "<group>";
@@ -471,6 +484,7 @@
 				945D40E7217A4AA7008ACFD0 /* Errors */,
 				945421722187882E00932CAF /* Extensions */,
 				945D40EA217A6081008ACFD0 /* HTTP */,
+				2CC93865270292D000465C19 /* Logger */,
 				94C3BD91219B0CB100B4A3E2 /* Services */,
 				94B6BD0621762D17005454C6 /* Info.plist */,
 			);
@@ -790,6 +804,7 @@
 				94C185E922D8DEF200CD66DC /* FailableDataRepresentable.swift in Sources */,
 				949AD28B218B375400808C79 /* FileType.swift in Sources */,
 				9430734422D7AFDA00AEAC8D /* BlobCache.swift in Sources */,
+				2CC938672702930800465C19 /* KumoLogger.swift in Sources */,
 				94A4E67B22DCF3660033B480 /* InMemory.swift in Sources */,
 				94A4E67D22DCF38B0033B480 /* FileSystem.swift in Sources */,
 				945D4116217F6ADB008ACFD0 /* HTTPHeader.swift in Sources */,
@@ -818,6 +833,7 @@
 				946809A422C64E710077DBCE /* SimpleRequest.swift in Sources */,
 				9447837C22958ED200BE6960 /* XMLDecodingTests.swift in Sources */,
 				9422A352222B2F7A0038E451 /* NetworkTest.swift in Sources */,
+				2CC938642702916A00465C19 /* TestLogger.swift in Sources */,
 				9422A34F222B2CA40038E451 /* MockResponse.swift in Sources */,
 				B58694D12322B3CC006C20EE /* Epic.swift in Sources */,
 				B55A1178233E5D92006EAB34 /* Unkeyed.swift in Sources */,

--- a/Sources/Kumo/Logger/KumoLogger.swift
+++ b/Sources/Kumo/Logger/KumoLogger.swift
@@ -1,42 +1,46 @@
-import Foundation
 import Combine
+import Foundation
 
 
 public protocol KumoLogger {
  
-    func log(error: Error?, message: String)
+    func log(message: String, error: Error?)
+    
 }
 
 extension KumoLogger {
     
     func logRequest(_ request: URLRequest) {
-        log(error: nil, message: "Request: \(request)")
+        log(message: "Request: \(request)", error: nil)
     }
     
     func logError(_ error: Error) {
-        log(error: error, message: "Error with request")
+        log(message: "Error with request", error: nil)
     }
     
     func logRawResponse(_ data: Data?) {
         if let data = data {
-            log(error: nil, message: "Raw Response: \(String(data: data, encoding: .utf8) ?? "Error converting to String")")
+            log(message: "Raw Response: \(String(data: data, encoding: .utf8) ?? "Error converting to String")", error: nil)
         } else {
-            log(error: nil, message: "Raw Response: nil")
+            log(message: "Raw Response: nil", error: nil)
         }
     }
+    
 }
 
 extension Publisher {
+    
     func logPublisher(_ logger: KumoLogger?) -> Publishers.HandleEvents<Self> {
         handleEvents(receiveOutput: { output in
-            logger?.log(error: nil, message: "Sucess: \(output)")
+            logger?.log( message: "Sucess: \(output)", error: nil)
         }, receiveCompletion: { completion in
             switch completion {
             case .failure(let error):
-                logger?.log(error: error, message: "Error with request")
+                logger?.log(error: error, message: "Error with request", error: nil)
             case .finished:
                 ()
             }
         })
     }
+    
 }

--- a/Sources/Kumo/Logger/KumoLogger.swift
+++ b/Sources/Kumo/Logger/KumoLogger.swift
@@ -1,46 +1,99 @@
 import Combine
 import Foundation
 
-
 public protocol KumoLogger {
- 
+
     func log(message: String, error: Error?)
+
+    /// The array of KumoLoggerLevel to log. Used to control how fine grain the logging is. If this array is empty that is the same as disabling logging
+    var levels: [KumoLoggerLevel] { get }
+
+}
+
+/// Controlls the level of logging in Kumo.
+public enum KumoLoggerLevel: CaseIterable {
+    /// Logs the URLRequest inculding errors.
+    case request
+    /// Logs the URLResponse inculding errors.
+    case response
+    /// Logs the response data as a String including errors.
+    case responseData
+    /// Logs the result of the response data decoding inculding errors.
+    case responseDecoding
+    /// Only logs errors.
+    case error
+    
+    /// Adds all of the logging levels.
+    public static var all: [KumoLoggerLevel] {
+        allCases
+    }
     
 }
 
 extension KumoLogger {
-    
+
     func logRequest(_ request: URLRequest) {
+        guard levels.contains(.request) else {
+            return
+        }
         log(message: "Request: \(request)", error: nil)
     }
-    
-    func logError(_ error: Error) {
-        log(message: "Error with request", error: nil)
+
+    func logRequestError(_ error: Error) {
+        // If error is set ignore this log. The error will get caught in the publisher.
+        guard levels.contains(.request), !levels.contains(.error) else {
+            return
+        }
+        log(message: "Error with request", error: error)
     }
-    
+
+    func logResponse(_ response: URLResponse) {
+        guard levels.contains(.response) else {
+            return
+        }
+        log(message: "Response: \(response)", error: nil)
+    }
+
+    func logResponseError(_ error: Error) {
+        // If error is set ignore this log. The error will get caught in the publisher.
+        guard levels.contains(.response), !levels.contains(.error) else {
+            return
+        }
+        log(message: "Error with response", error: error)
+    }
+
     func logRawResponse(_ data: Data?) {
+        guard levels.contains(.responseData) else {
+            return
+        }
         if let data = data {
             log(message: "Raw Response: \(String(data: data, encoding: .utf8) ?? "Error converting to String")", error: nil)
         } else {
             log(message: "Raw Response: nil", error: nil)
         }
     }
-    
+
 }
 
 extension Publisher {
-    
+
     func logPublisher(_ logger: KumoLogger?) -> Publishers.HandleEvents<Self> {
         handleEvents(receiveOutput: { output in
-            logger?.log( message: "Sucess: \(output)", error: nil)
+            guard let logger = logger, logger.levels.contains(.responseDecoding) else {
+                return
+            }
+            logger.log(message: "Decoded Response: \(output)", error: nil)
         }, receiveCompletion: { completion in
             switch completion {
             case .failure(let error):
-                logger?.log(message: "Error with request", error: error)
+                guard let logger = logger, logger.levels.contains(.responseDecoding) || logger.levels.contains(.error) else {
+                    return
+                }
+                logger.log(message: "Error with request or response", error: error)
             case .finished:
                 ()
             }
         })
     }
-    
+
 }

--- a/Sources/Kumo/Logger/KumoLogger.swift
+++ b/Sources/Kumo/Logger/KumoLogger.swift
@@ -36,7 +36,7 @@ extension Publisher {
         }, receiveCompletion: { completion in
             switch completion {
             case .failure(let error):
-                logger?.log(error: error, message: "Error with request", error: nil)
+                logger?.log(message: "Error with request", error: error)
             case .finished:
                 ()
             }

--- a/Sources/Kumo/Logger/KumoLogger.swift
+++ b/Sources/Kumo/Logger/KumoLogger.swift
@@ -1,0 +1,42 @@
+import Foundation
+import Combine
+
+
+public protocol KumoLogger {
+ 
+    func log(error: Error?, message: String)
+}
+
+extension KumoLogger {
+    
+    func logRequest(_ request: URLRequest) {
+        log(error: nil, message: "Request: \(request)")
+    }
+    
+    func logError(_ error: Error) {
+        log(error: error, message: "Error with request")
+    }
+    
+    func logRawResponse(_ data: Data?) {
+        if let data = data {
+            log(error: nil, message: "Raw Response: \(String(data: data, encoding: .utf8) ?? "Error converting to String")")
+        } else {
+            log(error: nil, message: "Raw Response: nil")
+        }
+    }
+}
+
+extension Publisher {
+    func logPublisher(_ logger: KumoLogger?) -> Publishers.HandleEvents<Self> {
+        handleEvents(receiveOutput: { output in
+            logger?.log(error: nil, message: "Sucess: \(output)")
+        }, receiveCompletion: { completion in
+            switch completion {
+            case .failure(let error):
+                logger?.log(error: error, message: "Error with request")
+            case .finished:
+                ()
+            }
+        })
+    }
+}

--- a/Sources/Kumo/Services/Service.swift
+++ b/Sources/Kumo/Services/Service.swift
@@ -107,7 +107,7 @@ public class Service {
     ///   performed in the background.
     ///   - configuration: A block for making initial modifications to the
     ///   [`URLSessionConfiguration`](https://developer.apple.com/documentation/foundation/urlsessionconfiguration).
-    public init(baseURL: URL?, runsInBackground: Bool = false,logger: KumoLogger? = nil, configuration: ((URLSessionConfiguration) -> Void)? = nil) {
+    public init(baseURL: URL?, runsInBackground: Bool = false, logger: KumoLogger? = nil, configuration: ((URLSessionConfiguration) -> Void)? = nil) {
         self.baseURL = baseURL
         self.logger = logger
         let sessionConfiguration = runsInBackground ? URLSessionConfiguration.background(withIdentifier: baseURL?.absoluteString ?? UUID().uuidString) : .default

--- a/Tests/KumoTests/Fixtures/Common/NetworkTest.swift
+++ b/Tests/KumoTests/Fixtures/Common/NetworkTest.swift
@@ -4,7 +4,7 @@ import Foundation
 import XCTest
 
 class NetworkTest: XCTestCase {
-    let service = Service(baseURL: URL(string: "https://httpbin.org")!)
+    let service = Service(baseURL: URL(string: "https://httpbin.org")!, logger: TestLogger())
 
     let parameters: (actual: [String: Any], expected: [String: String]) = {
         let base: [String: Any] = ["foo": 1, "bar": "foo"]

--- a/Tests/KumoTests/Fixtures/Common/TestLogger.swift
+++ b/Tests/KumoTests/Fixtures/Common/TestLogger.swift
@@ -1,0 +1,12 @@
+import Foundation
+@testable import Kumo
+
+class TestLogger: KumoLogger {
+    func log(error: Error?, message: String) {
+        if error == nil {
+            print("API - \(message)")
+        } else {
+            print("API - Error: \(String(describing: error)) - \(message)")
+        }
+    }
+}

--- a/Tests/KumoTests/Fixtures/Common/TestLogger.swift
+++ b/Tests/KumoTests/Fixtures/Common/TestLogger.swift
@@ -2,11 +2,17 @@ import Foundation
 @testable import Kumo
 
 class TestLogger: KumoLogger {
-    func log(error: Error?, message: String) {
+
+    func log(message: String, error: Error?) {
         if error == nil {
             print("API - \(message)")
         } else {
             print("API - Error: \(String(describing: error)) - \(message)")
         }
     }
+
+    var levels: [KumoLoggerLevel] {
+        KumoLoggerLevel.all
+    }
+
 }


### PR DESCRIPTION
This is to get the discussion started on adding some global logging to Kumo to help in debugging API response to better the developer experience.

Added basic logging to the service that logs:
- the request
- the raw response as a string 
- and the decoded object.

See this screenshot for the logs:

<img width="577" alt="Logs screen shot" src="https://user-images.githubusercontent.com/813257/135003834-e0c30fbc-3233-4175-8868-ffa01e6808f0.png">

Things I think we should add:
- I think it needs logging levels like OkHttp: https://square.github.io/okhttp/3.x/logging-interceptor/okhttp3/logging/HttpLoggingInterceptor.Level.html
- Add logging of the response object.

Eventually, I want to add a UI component to Kumo to add in something that looks like [Chucker on Android](https://github.com/ChuckerTeam/chucker). It works off of the [OKHttp interceptor](https://square.github.io/okhttp/interceptors/). So maybe we build something like the OKHttp interceptor for Kumo but read-only so we can use it for both logging and displaying the raw data in a fancy UI for other developers and a QA to view?



