### PR TITLE
Remove invalidation while session is valid.

### DIFF
--- a/Sources/Kumo/Extensions/URLSession.swift
+++ b/Sources/Kumo/Extensions/URLSession.swift
@@ -8,8 +8,9 @@ class URLSessionInvalidationDelegate: NSObject, URLSessionDelegate, Invalidation
     fileprivate var invalidations = [URLSession: (URLSession, Error?) -> Void]()
 
     func urlSession(_ session: URLSession, didBecomeInvalidWithError error: Error?) {
-        invalidations[session]?(session, error)
+        guard let invalidation = invalidations[session] else { return }
         invalidations[session] = nil
+        invalidation(session, error)
     }
 
     override func conforms(to aProtocol: Protocol) -> Bool {
@@ -27,8 +28,9 @@ class URLSessionThreadSafeInvalidationDelegate: NSObject, URLSessionDelegate, In
 
     func urlSession(_ session: URLSession, didBecomeInvalidWithError error: Error?) {
         invalidationQueue.sync {
-            invalidations[session]?(session, error)
+            guard let invalidation = invalidations[session] else { return }
             invalidations[session] = nil
+            invalidation(session, error)
         }
     }
 


### PR DESCRIPTION
Attempting to set: `invalidations[session] = nil` would sometimes crash due to bad memory access, presumably because the invalidation closure has run and the session is no longer valid.

This update grabs the invalidation closure, then removes it from the map, then calls the closure to invalidate.