### PR TITLE
fix: exclude Info.plist files from SPM targets to eliminate build warnings

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -16,6 +16,7 @@ let package = Package(
         .target(
             name: "Kumo",
             dependencies: ["KumoCoding"],
+            exclude: ["Info.plist"],
             swiftSettings: [
                 .swiftLanguageMode(.v6)
             ]
@@ -23,6 +24,7 @@ let package = Package(
         .target(
             name: "KumoCoding",
             dependencies: [],
+            exclude: ["Info.plist"],
             swiftSettings: [
                 .swiftLanguageMode(.v6)
             ]
@@ -30,6 +32,7 @@ let package = Package(
         .testTarget(
             name: "KumoTests",
             dependencies: ["Kumo", "KumoCoding"],
+            exclude: ["Info.plist"],
             swiftSettings: [
                 .swiftLanguageMode(.v6)
             ]


### PR DESCRIPTION
## Summary

Excludes `Info.plist` files from all three SPM targets (`Kumo`, `KumoCoding`, `KumoTests`) to eliminate the "found file(s) which are unhandled" build warnings.

### Changes
- **Package.swift** — added `exclude: ["Info.plist"]` to each target

### Result
- `swift build -Xswiftc -strict-concurrency=complete` passes with **zero warnings**
- Single 1-file, 3-line change on top of ver/3.0.0 (no conflicts)