### PR TITLE
fix: make FileSystem init directory creation race-safe

### DIFF
--- a/Sources/Kumo/Blobs/Storage/FileSystem.swift
+++ b/Sources/Kumo/Blobs/Storage/FileSystem.swift
@@ -14,7 +14,14 @@ class FileSystem: StorageLocation {
         self.parentDirectory = parentDirectory ?? backingManager.cachesDirectory
             .appendingPathComponent("\(bundle.bundleIdentifier ?? "kumo.caches").\(Bundle.main.bundleIdentifier ?? "filecache")")
         // Idempotent creation avoids a check-then-create race when cache setup happens concurrently.
-        try? backingManager.createDirectory(at: self.parentDirectory, withIntermediateDirectories: true, attributes: nil)
+        do {
+            try backingManager.createDirectory(at: self.parentDirectory, withIntermediateDirectories: true, attributes: nil)
+        } catch {
+            // Concurrent creation can still surface as a file-exists error; ignore that case.
+            if !(error as NSError).isFileExistsError {
+                assertionFailure("Failed to create cache directory at \(self.parentDirectory.path): \(error)")
+            }
+        }
     }
 
     func fetch<D: _DataRepresentable>(for url: URL, arguments: D._RepresentationArguments) throws -> D? {

--- a/Sources/Kumo/Blobs/Storage/FileSystem.swift
+++ b/Sources/Kumo/Blobs/Storage/FileSystem.swift
@@ -13,8 +13,8 @@ class FileSystem: StorageLocation {
         let bundle = Bundle(for: type(of: self))
         self.parentDirectory = parentDirectory ?? backingManager.cachesDirectory
             .appendingPathComponent("\(bundle.bundleIdentifier ?? "kumo.caches").\(Bundle.main.bundleIdentifier ?? "filecache")")
-        if backingManager.fileExists(atPath: self.parentDirectory.path) { return }
-        try! backingManager.createDirectory(at: self.parentDirectory, withIntermediateDirectories: false, attributes: nil)
+        // Idempotent creation avoids a check-then-create race when cache setup happens concurrently.
+        try? backingManager.createDirectory(at: self.parentDirectory, withIntermediateDirectories: true, attributes: nil)
     }
 
     func fetch<D: _DataRepresentable>(for url: URL, arguments: D._RepresentationArguments) throws -> D? {

--- a/Tests/KumoTests/Fixtures/Blobs/FileSystemInitializationTests.swift
+++ b/Tests/KumoTests/Fixtures/Blobs/FileSystemInitializationTests.swift
@@ -1,0 +1,36 @@
+import Foundation
+@testable import Kumo
+import XCTest
+
+final class FileSystemInitializationTests: XCTestCase {
+
+    func testInitDoesNotTrapWhenDirectoryCreationReturnsFileExists() {
+        let backingManager = FileExistsErrorFileManager()
+        let parentDirectory = URL(fileURLWithPath: NSTemporaryDirectory(), isDirectory: true)
+            .appendingPathComponent(UUID().uuidString, isDirectory: true)
+
+        XCTAssertNoThrow(FileSystem(backingManager: backingManager, parentDirectory: parentDirectory))
+    }
+
+    func testInitIsIdempotentWhenParentDirectoryAlreadyExists() throws {
+        let backingManager = FileManager.default
+        let parentDirectory = URL(fileURLWithPath: NSTemporaryDirectory(), isDirectory: true)
+            .appendingPathComponent(UUID().uuidString, isDirectory: true)
+
+        try backingManager.createDirectory(at: parentDirectory, withIntermediateDirectories: true, attributes: nil)
+        defer { try? backingManager.removeItem(at: parentDirectory) }
+
+        XCTAssertNoThrow(FileSystem(backingManager: backingManager, parentDirectory: parentDirectory))
+        XCTAssertNoThrow(FileSystem(backingManager: backingManager, parentDirectory: parentDirectory))
+    }
+}
+
+private final class FileExistsErrorFileManager: FileManager {
+    override func createDirectory(
+        at url: URL,
+        withIntermediateDirectories createIntermediates: Bool,
+        attributes: [FileAttributeKey: Any]? = nil
+    ) throws {
+        throw NSError(domain: NSCocoaErrorDomain, code: 516)
+    }
+}


### PR DESCRIPTION
## Technical Changes
- Replaced the check-then-create pattern in `FileSystem.init` with idempotent directory creation.
- Removed fatal `try!` trap risk during concurrent cache initialization by using `try? createDirectory(..., withIntermediateDirectories: true, ...)`.
- Added regression tests in `Tests/KumoTests/Fixtures/Blobs/FileSystemInitializationTests.swift` for:
  - file-exists error path during initialization
  - idempotent initialization when directory already exists

## Reason
This addresses launch-time crashes caused by a race in cache directory creation (`BlobCache`/`FileSystem` init) under concurrent first access.

## Validation
- Ran: `swift test --filter FileSystemInitializationTests`
- Result: 2 tests passed, 0 failures